### PR TITLE
修复Unicode码点值范围超过0x10000时序列化和反序列化错误

### DIFF
--- a/ajson.hpp
+++ b/ajson.hpp
@@ -1452,7 +1452,7 @@ namespace ajson
       str.append(1, (char)(0xC0 | ((utf1 >> 6) & 0xFF)));
       str.append(1, (char)(0x80 | ((utf1 & 0x3F))));
     }
-    else if (utf1 < 0x80000)
+    else if (utf1 < 0x10000)
     {
       str.append(1, (char)(0xE0 | ((utf1 >> 12) & 0xFF)));
       str.append(1, (char)(0x80 | ((utf1 >> 6) & 0x3F)));
@@ -1460,7 +1460,7 @@ namespace ajson
     }
     else
     {
-      if (utf1 < 0x110000)
+      if (utf1 >= 0x110000)
       {
         return false;
       }

--- a/ajson.hpp
+++ b/ajson.hpp
@@ -1037,23 +1037,23 @@ namespace ajson
               }
               else
               {
-                unsigned char c1 = (uint8_t)(codepoint >> 24);
-                unsigned char c2 = (uint8_t)(codepoint >> 16);
-                unsigned char c3 = (uint8_t)(codepoint >> 8);
-                unsigned char c4 = (uint8_t)codepoint;
+                // utf-16 surrogate pair encoding (\uXXXX\uYYYY)
+                uint32_t cp_prime = codepoint - 0x10000;
+                uint16_t high = 0xD800 + (cp_prime >> 10);
+                uint16_t low  = 0xDC00 + (cp_prime & 0x3FF);
 
                 put('\\');
                 put('u');
-                put(hex_table[(c1) >> 4]);
-                put(hex_table[(c1)& 0xF]);
-                put(hex_table[(c2) >> 4]);
-                put(hex_table[(c2)& 0xF]);
+                put(hex_table[(high >> 12) & 0xF]);
+                put(hex_table[(high >> 8) & 0xF]);
+                put(hex_table[(high >> 4) & 0xF]);
+                put(hex_table[high & 0xF]);
                 put('\\');
                 put('u');
-                put(hex_table[(c3) >> 4]);
-                put(hex_table[(c3)& 0xF]);
-                put(hex_table[(c4) >> 4]);
-                put(hex_table[(c4)& 0xF]);
+                put(hex_table[(low >> 12) & 0xF]);
+                put(hex_table[(low >> 8) & 0xF]);
+                put(hex_table[(low >> 4) & 0xF]);
+                put(hex_table[low & 0xF]);
               }
             }
             else
@@ -1555,7 +1555,7 @@ namespace ajson
     } while (len > 0);
     return true;
   }
-  
+
   template<typename ty>
   struct json_impl < ty,
     typename std::enable_if <detail::is_stdstring<ty>::value>::type >


### PR DESCRIPTION
修复Unicode码点值范围超过0x10000时序列化和反序列化错误
1. 启用代理对处理规则
2. 修复utf8字符范围判断错误

修复前处理😴这个emoji字符序列化时会出错，它的码点值U+1F634，序列化成 `\u0001\uF634` 输出到终端是无法显示，需要使用代理对，转化成`\uD83D\uDE34`才可以